### PR TITLE
update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 [tool.poetry]
-name = "CodaMOSA"
-version = "0.1.0"
+name = "pynguin"
+version = "0.19.0"
 description = "A tool to conduct LLM-aided search-based unit test generation"
 authors = ["Caroline Lemieux", "Stephan Lukasczyk <stephan@lukasczyk.me>"]
 license = "MIT"


### PR DESCRIPTION
Update pyproject.toml to have the pynguin version to allow the docker container to be built correctly (Issue #9).

Turns out the poetry name field is the actual package name, not just something. 

This is a quick fix; in the long term we should rename everything to codamosa throughout. 